### PR TITLE
Entity load fix

### DIFF
--- a/ManiacEditor/EditorEntity.cs
+++ b/ManiacEditor/EditorEntity.cs
@@ -985,6 +985,9 @@ namespace ManiacEditor
                     try
                     {
                         editorAnim = LoadAnimation("Platform", d, aminID, -1, false, false, false);
+
+                        if (editorAnim == null) return; // no animation, bail out
+
                         frameID += editorAnim.Frames.Count;
                         if (targetFrameID < frameID)
                         {
@@ -1019,7 +1022,7 @@ namespace ManiacEditor
             DataDirectoryList = null;
 
             foreach (var pair in Sheets)
-                pair.Value.Dispose();
+                pair.Value?.Dispose();
             Sheets.Clear();
 
             foreach (var pair in Animations)

--- a/ManiacEditor/EditorEntity.cs
+++ b/ManiacEditor/EditorEntity.cs
@@ -299,14 +299,28 @@ namespace ManiacEditor
                 Bitmap map;
                 if (!Sheets.ContainsKey(rsdkAnim.SpriteSheets[frame.SpriteSheet]))
                 {
-                    map = new Bitmap(Path.Combine(Editor.DataDirectory, "sprites", rsdkAnim.SpriteSheets[frame.SpriteSheet].Replace('/', '\\')));
-                    Sheets.Add(rsdkAnim.SpriteSheets[frame.SpriteSheet], map);
+                    string targetFile = Path.Combine(Editor.DataDirectory, "sprites", rsdkAnim.SpriteSheets[frame.SpriteSheet].Replace('/', '\\'));
+                    if (!File.Exists(targetFile))
+                    {
+                        map = null;
+                        // add a Null to our lookup, so we can avoid looking again in the future
+                        Sheets.Add(rsdkAnim.SpriteSheets[frame.SpriteSheet], map);
+                    }
+                    else
+                    {
+                        map = new Bitmap(targetFile);
+                        Sheets.Add(rsdkAnim.SpriteSheets[frame.SpriteSheet], map);
+                    }
                 }
                 else
                     map = Sheets[rsdkAnim.SpriteSheets[frame.SpriteSheet]];
 
                 if (frame.Width == 0 || frame.Height == 0)
                     continue;
+
+                // can't load the animation, it probably doesn't exist in the User's Sprites folder
+                if (map == null) return null;
+
                 // We are storing the first colour from the palette so we can use it to make sprites transparent
                 var colour = map.Palette.Entries[0];
                 // Slow


### PR DESCRIPTION
Rethought this. While it's possible to still get Manaic to load the wrong sprite, the extra crash protection is all good by what I've seen so far.

Let's get that added, and worry about edge cases of missing files later.