### PR TITLE
Fix potential leak when creating a GameConfig object.

### DIFF
--- a/RSDKv5/GameConfig.cs
+++ b/RSDKv5/GameConfig.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
+using System.Linq;
 
 namespace RSDKv5
 {
@@ -93,19 +91,21 @@ namespace RSDKv5
 
         public List<ConfigurableMemoryEntry> ConfigMemory = new List<ConfigurableMemoryEntry>();
 
-        public GameConfig(string filename) : this(new Reader(filename))
+        public GameConfig(string filename)
         {
-
+            using (var reader = new Reader(filename))
+                Read(reader);
         }
 
-        public GameConfig(Stream stream) : this(new Reader(stream))
+        public GameConfig(Stream stream)
         {
-
+            using (var reader = new Reader(stream))
+                Read(reader);
         }
 
-        private GameConfig(Reader reader)
+        private void Read(Reader reader)
         {
-            base.ReadMagic(reader);
+            ReadMagic(reader);
 
             GameName = reader.ReadRSDKString();
             GameSubname = reader.ReadRSDKString();
@@ -116,7 +116,7 @@ namespace RSDKv5
             StartSceneCategoryIndex = reader.ReadByte();
             StartSceneIndex = reader.ReadUInt16();
 
-            base.ReadCommonConfig(reader);
+            ReadCommonConfig(reader);
 
             ushort TotalScenes = reader.ReadUInt16();
 
@@ -142,18 +142,18 @@ namespace RSDKv5
         public void Write(string filename)
         {
             using (Writer writer = new Writer(filename))
-                this.Write(writer);
+                Write(writer);
         }
 
         public void Write(Stream stream)
         {
             using (Writer writer = new Writer(stream))
-                this.Write(writer);
+                Write(writer);
         }
 
         internal void Write(Writer writer)
         {
-            base.WriteMagic(writer);
+            WriteMagic(writer);
 
             writer.WriteRSDKString(GameName);
             writer.WriteRSDKString(GameSubname);
@@ -162,7 +162,7 @@ namespace RSDKv5
             writer.Write(StartSceneCategoryIndex);
             writer.Write(StartSceneIndex);
 
-            base.WriteCommonConfig(writer);
+            WriteCommonConfig(writer);
 
             writer.Write((ushort)Categories.Select(x => x.Scenes.Count).Sum());
 


### PR DESCRIPTION
 Turn the private constructor into a regular method, and just place it behind a Using.

I think there's a few more of these lurking in the RSDKv5 library, but they can tackled as-and-when.