### PR TITLE
External objects ini

### DIFF
--- a/ManiacEditor/ManiacEditor.csproj
+++ b/ManiacEditor/ManiacEditor.csproj
@@ -206,7 +206,9 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <EmbeddedResource Include="Resources\objects_attributes.ini" />
+    <Content Include="Resources\objects_attributes.ini">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Resources\LayerManagerWarning.rtf" />
     <None Include="Resources\ObjectWarning.rtf" />
     <None Include="Resources\SoundWarning.rtf" />

--- a/ManiacEditor/Program.cs
+++ b/ManiacEditor/Program.cs
@@ -51,8 +51,9 @@ Missing file: {fnfe.FileName}");
 
         private static string GetExecutingDirectoryName()
         {
-            var location = new Uri(Assembly.GetEntryAssembly().GetName().CodeBase);
-            return new FileInfo(location.AbsolutePath).Directory.FullName;
+            string exeLocationUrl = Assembly.GetEntryAssembly().GetName().CodeBase;
+            string exeLocation = new Uri(exeLocationUrl).LocalPath;
+            return new FileInfo(exeLocation).Directory.FullName;
         }
 
         private static FileStream GetObjectsIniResource()

--- a/ManiacEditor/Program.cs
+++ b/ManiacEditor/Program.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace ManiacEditor
@@ -18,12 +15,60 @@ namespace ManiacEditor
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
-            using (var stream = Assembly.GetExecutingAssembly().GetManifestResourceStream("ManiacEditor.Resources.objects_attributes.ini"))
+
+            bool allowedToLoad = false;
+            try
             {
-                RSDKv5.Objects.InitObjects(stream);
+                using (var stream = GetObjectsIniResource())
+                {
+                    RSDKv5.Objects.InitObjects(stream);
+                    allowedToLoad = true;
+                }
             }
-            new Editor().Run();
-            //Application.Run(new GUI.MapEditor());
+            catch (FileNotFoundException fnfe)
+            {
+                DisplayLoadFailure($@"{fnfe.Message}
+Missing file: {fnfe.FileName}");
+            }
+            catch (Exception e)
+            {
+                DisplayLoadFailure(e.Message);
+            }
+
+            if (allowedToLoad)
+            {
+                new Editor().Run();
+            }
+        }
+
+        private static void DisplayLoadFailure(string message)
+        {
+            MessageBox.Show(message,
+                            "Unable to start.",
+                            MessageBoxButtons.OK,
+                            MessageBoxIcon.Error);
+        }
+
+        private static string GetExecutingDirectoryName()
+        {
+            var location = new Uri(Assembly.GetEntryAssembly().GetName().CodeBase);
+            return new FileInfo(location.AbsolutePath).Directory.FullName;
+        }
+
+        private static FileStream GetObjectsIniResource()
+        {
+            string executingDirectory = GetExecutingDirectoryName();
+            string fullPathToIni = executingDirectory + @"\Resources\objects_attributes.ini";
+            if (!File.Exists(fullPathToIni))
+            {
+                throw new FileNotFoundException("Unable to find the required file for naming objects and attributes.", 
+                                                @"\Resources\objects_attributes.ini");
+            }
+
+            return new FileStream(fullPathToIni,
+                                  FileMode.Open,
+                                  FileAccess.Read,
+                                  FileShare.Read);
         }
     }
 }

--- a/ManiacEditor/Resources/objects_attributes.ini
+++ b/ManiacEditor/Resources/objects_attributes.ini
@@ -1499,6 +1499,7 @@ filter=UINT8
 [PBL_Flipper]
 filter=UINT8
 retractable=BOOL
+minCraneID=UINT8
 
 [PBL_Ring]
 filter=UINT8

--- a/ManiacEditor/Resources/objects_attributes.ini
+++ b/ManiacEditor/Resources/objects_attributes.ini
@@ -8,6 +8,7 @@ duration=UINT16
 filter=UINT8
 
 [AIZEncoreTutorial]
+filter=UINT8
 
 [AIZEggRobo]
 filter=UINT8
@@ -607,6 +608,7 @@ size=POSITION
 
 [EncoreRoute]
 filter=UINT8
+offset=POSITION
 size=POSITION
 
 [ERZGunner]
@@ -694,6 +696,8 @@ frameID=VAR
 
 [FernParallax]
 filter=UINT8
+aniID=UINT8
+parallaxFactor=POSITION
 
 [FilmProjector]
 filter=UINT8
@@ -749,6 +753,7 @@ orientation=UINT8
 
 [FlingRamp]
 filter=UINT8
+direction=UINT8
 
 [Flipper]
 filter=UINT8
@@ -882,6 +887,9 @@ filter=UINT8
 type=VAR
 size=VAR
 noSwing=BOOL
+
+[HangGlider]
+filter=UINT8
 
 [HandLauncher]
 filter=UINT8
@@ -1266,6 +1274,9 @@ filter=UINT8
 type=UINT8
 height=VAR
 radius=VAR
+
+[LRZ1Introsize]
+filter=UINT8
 
 [MagnetSphere]
 filter=UINT8
@@ -1696,6 +1707,9 @@ fanEnabled=BOOL
 [PropellerShaft]
 filter=UINT8
 size=VAR
+
+[PSZ1Intro]
+filter=UINT8
 
 [PSZ1Setup]
 filter=UINT8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-- cmd: 7z a ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\LICENSE
+- cmd: 7z a ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\Resources %APPVEYOR_BUILD_FOLDER%\LICENSE
 artifacts:
 - path: ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip
   name: ManiacEditor-Positivity


### PR DESCRIPTION
Move the objects.ini file out to its own file, rather than being an embedded resource.
This way, people may edit/update it directly, without waiting for a formal build.