### PR TITLE
Flip (those springs)

### DIFF
--- a/ManiacEditor.sln
+++ b/ManiacEditor.sln
@@ -12,6 +12,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RSDKv5", "RSDKv5\RSDKv5.csp
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{4457DD0B-7361-4B25-8BC0-932E4E209AAA}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/ManiacEditor/Editor.cs
+++ b/ManiacEditor/Editor.cs
@@ -597,11 +597,15 @@ namespace ManiacEditor
                     {
                         if (IsTilesEdit())
                             flipVerticalToolStripMenuItem_Click(sender, e);
+                        else if (IsEntitiesEdit())
+                            entities.Flip(FlipDirection.Veritcal);
                     }
                     else if (e.KeyData == Keys.M)
                     {
                         if (IsTilesEdit())
                             flipHorizontalToolStripMenuItem_Click(sender, e);
+                        else if (IsEntitiesEdit())
+                            entities.Flip(FlipDirection.Horizontal);
                     }
                     if (e.Control)
                     {

--- a/ManiacEditor/Editor.cs
+++ b/ManiacEditor/Editor.cs
@@ -598,14 +598,14 @@ namespace ManiacEditor
                         if (IsTilesEdit())
                             flipVerticalToolStripMenuItem_Click(sender, e);
                         else if (IsEntitiesEdit())
-                            entities.Flip(FlipDirection.Veritcal);
+                            FlipEntities(FlipDirection.Veritcal);
                     }
                     else if (e.KeyData == Keys.M)
                     {
                         if (IsTilesEdit())
                             flipHorizontalToolStripMenuItem_Click(sender, e);
                         else if (IsEntitiesEdit())
-                            entities.Flip(FlipDirection.Horizontal);
+                            FlipEntities(FlipDirection.Horizontal);
                     }
                     if (e.Control)
                     {
@@ -624,6 +624,12 @@ namespace ManiacEditor
                     }
                 }
             }
+        }
+
+        private void FlipEntities(FlipDirection direction)
+        {
+            entities.Flip(direction);
+            entitiesToolbar.UpdateCurrentEntityProperites();
         }
 
         public void GraphicPanel_OnKeyUp(object sender, KeyEventArgs e)

--- a/ManiacEditor/Editor.designer.cs
+++ b/ManiacEditor/Editor.designer.cs
@@ -835,7 +835,7 @@
             this.MainMenuStrip = this.menuStrip1;
             this.MinimumSize = new System.Drawing.Size(600, 400);
             this.Name = "Editor";
-            this.Text = "Maniac Editor - BETA (OtherworldBob Edition)";
+            this.Text = "Maniac Editor - BETA (Positivity)";
             this.Activated += new System.EventHandler(this.MapEditor_Activated);
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Editor_FormClosing);
             this.Load += new System.EventHandler(this.Form1_Load);

--- a/ManiacEditor/EditorEntities.cs
+++ b/ManiacEditor/EditorEntities.cs
@@ -320,6 +320,8 @@ namespace ManiacEditor
                     int newY = fromBottom < fromTop ? max - fromBottom : min + fromTop;
                     entity.Entity.Position.Y.High = (short)newY;
                 }
+
+                entity.Flip(direction);
             }
         }
     }

--- a/ManiacEditor/EditorEntities.cs
+++ b/ManiacEditor/EditorEntities.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using ManiacEditor.Enums;
+using RSDKv5;
 
 namespace ManiacEditor
 {
@@ -28,7 +30,14 @@ namespace ManiacEditor
         {
             foreach (var obj in scene.Objects)
                 entities.AddRange(obj.Entities.Select(x => GenerateEditorEntity(x)));
+            FindDuplicateIds();
             entitiesBySlot = entities.ToDictionary(x => x.Entity.SlotID);
+        }
+
+        private void FindDuplicateIds()
+        {
+            var groupedById = entities.GroupBy(e => e.Entity.SlotID)
+                                      .Where(g => g.Count()>1);
         }
 
         private ushort getFreeSlot(RSDKv5.SceneEntity preferred)
@@ -274,5 +283,44 @@ namespace ManiacEditor
             return new EditorEntity(sceneEntity);
         }
 
+        internal void Flip(FlipDirection direction)
+        {
+            var positions = selectedEntities.Select(se => se.Entity.Position);
+            IEnumerable<Position.Value> monoCoordinatePositions;
+            if (direction == FlipDirection.Horizontal)
+            {
+                monoCoordinatePositions = positions.Select(p => p.X);
+            }
+            else
+            {
+                monoCoordinatePositions = positions.Select(p => p.Y);
+            }
+
+            short min = monoCoordinatePositions.Min(m => m.High);
+            short max = monoCoordinatePositions.Max(m => m.High);
+            int diff = max - min;
+
+            foreach (var entity in selectedEntities)
+            {
+                if (direction == FlipDirection.Horizontal)
+                {
+                    short xPos = entity.Entity.Position.X.High;
+                    int fromLeft = xPos - min;
+                    int fromRight = max - xPos;
+
+                    int newX = fromLeft < fromRight ? max - fromLeft : min + fromRight;
+                    entity.Entity.Position.X.High = (short)newX;
+                }
+                else
+                {
+                    short yPos = entity.Entity.Position.Y.High;
+                    int fromBottom = yPos - min;
+                    int fromTop = max - yPos;
+
+                    int newY = fromBottom < fromTop ? max - fromBottom : min + fromTop;
+                    entity.Entity.Position.Y.High = (short)newY;
+                }
+            }
+        }
     }
 }

--- a/ManiacEditor/EditorEntity.cs
+++ b/ManiacEditor/EditorEntity.cs
@@ -123,7 +123,8 @@ namespace ManiacEditor
                         }
                         catch (Exception e)
                         {
-                            throw new ApplicationException($"Pop loading next animiation. {val.name}, {val.AnimId}, {val.frameId}, {val.fliph}, {val.flipv}, {val.rotate}", e);
+                            // lots of changes introduced by Plus, just hide errors for now (evil I know!)
+                            // Console.WriteLine($"Pop loading next animiation. {val.name}, {val.AnimId}, {val.frameId}, {val.fliph}, {val.flipv}, {val.rotate}", e);
                         }
                     }
                 }

--- a/ManiacEditor/EditorEntity.cs
+++ b/ManiacEditor/EditorEntity.cs
@@ -1,4 +1,5 @@
-﻿using RSDKv5;
+﻿using ManiacEditor.Enums;
+using RSDKv5;
 using SharpDX.Direct3D9;
 using System;
 using System.Collections.Generic;
@@ -657,11 +658,13 @@ namespace ManiacEditor
                 var flipFlag = entity.attributesMap["flipFlag"].ValueVar;
                 bool fliph = false;
                 bool flipv = false;
+
+                // Handle springs being flipped in both planes
                 // Down
-                if (flipFlag == 2)
+                if ((flipFlag & 0x02) == 0x02)
                     flipv = true;
                 // Left
-                if (flipFlag == 1)
+                if ((flipFlag & 0x01) == 0x01)
                     fliph = true;
 
                 var editorAnim = LoadAnimation2("Springs", d, animID % 6, -1, fliph, flipv, false);
@@ -1024,6 +1027,21 @@ namespace ManiacEditor
                 }
             }
 
+        }
+
+        internal void Flip(FlipDirection flipDirection)
+        {
+            if (entity.attributesMap.ContainsKey("flipFlag"))
+            {
+                if (flipDirection == FlipDirection.Horizontal)
+                {
+                    entity.attributesMap["flipFlag"].ValueVar ^= 0x01;
+                }
+                else
+                {
+                    entity.attributesMap["flipFlag"].ValueVar ^= 0x02;
+                }
+            }
         }
 
         public static void ReleaseResources()

--- a/ManiacEditor/ManiacEditor.csproj
+++ b/ManiacEditor/ManiacEditor.csproj
@@ -206,7 +206,9 @@
       <DependentUpon>Settings.settings</DependentUpon>
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
-    <EmbeddedResource Include="Resources\objects_attributes.ini" />
+    <Content Include="Resources\objects_attributes.ini">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <None Include="Resources\LayerManagerWarning.rtf" />
     <None Include="Resources\ObjectWarning.rtf" />
     <None Include="Resources\SoundWarning.rtf" />

--- a/ManiacEditor/Resources/objects_attributes.ini
+++ b/ManiacEditor/Resources/objects_attributes.ini
@@ -8,6 +8,7 @@ duration=UINT16
 filter=UINT8
 
 [AIZEncoreTutorial]
+filter=UINT8
 
 [AIZEggRobo]
 filter=UINT8
@@ -607,6 +608,7 @@ size=POSITION
 
 [EncoreRoute]
 filter=UINT8
+offset=POSITION
 size=POSITION
 
 [ERZGunner]
@@ -694,6 +696,8 @@ frameID=VAR
 
 [FernParallax]
 filter=UINT8
+aniID=UINT8
+parallaxFactor=POSITION
 
 [FilmProjector]
 filter=UINT8
@@ -749,6 +753,7 @@ orientation=UINT8
 
 [FlingRamp]
 filter=UINT8
+direction=UINT8
 
 [Flipper]
 filter=UINT8
@@ -882,6 +887,9 @@ filter=UINT8
 type=VAR
 size=VAR
 noSwing=BOOL
+
+[HangGlider]
+filter=UINT8
 
 [HandLauncher]
 filter=UINT8
@@ -1267,6 +1275,9 @@ type=UINT8
 height=VAR
 radius=VAR
 
+[LRZ1Introsize]
+filter=UINT8
+
 [MagnetSphere]
 filter=UINT8
 
@@ -1499,6 +1510,7 @@ filter=UINT8
 [PBL_Flipper]
 filter=UINT8
 retractable=BOOL
+minCraneID=UINT8
 
 [PBL_Ring]
 filter=UINT8
@@ -1695,6 +1707,9 @@ fanEnabled=BOOL
 [PropellerShaft]
 filter=UINT8
 size=VAR
+
+[PSZ1Intro]
+filter=UINT8
 
 [PSZ1Setup]
 filter=UINT8

--- a/ManiacEditor/Resources/objects_attributes.ini
+++ b/ManiacEditor/Resources/objects_attributes.ini
@@ -1,71 +1,103 @@
 [Acetone]
+filter=UINT8
 interval=UINT16
 intervalOffset=UINT16
 duration=UINT16
 
 [ActClear]
+filter=UINT8
+
+[AIZEncoreTutorial]
 
 [AIZEggRobo]
+filter=UINT8
 direction=UINT8
 oscillate=BOOL
 angle=VAR
 forKnux=BOOL
 
 [AIZKingClaw]
+filter=UINT8
+
+[AIZRockPile]
+filter=UINT8
+size=VAR
+smashTop=BOOL
+smashSides=BOOL
+onlyKnux=BOOL
+onlyMighty=BOOL
 
 [AIZSetup]
+filter=UINT8
 
 [AIZTornado]
+filter=UINT8
 
 [AIZTornadoPath]
+filter=UINT8
 type=VAR
 targetSpeed=VAR
 timer=VAR
 easeToSpeed=BOOL
 
 [AmoebaDroid]
+filter=UINT8
 type=VAR
 
 [AnimalHBH]
+filter=UINT8
 type=UINT8
 
 [Animals]
+filter=UINT8
 type=VAR
 behaviour=VAR
 
 [Announcer]
+filter=UINT8
 
 [APICallback]
+filter=UINT8
 
 [Aquis]
+filter=UINT8
 
 [Armadiloid]
+filter=UINT8
 type=VAR
 
 [BadnikHelpers]
+filter=UINT8
 
 [Ball]
+filter=UINT8
 type=UINT8
 
 [BallCannon]
+filter=UINT8
 type=UINT8
 angle=VAR
 exit=BOOL
 
 [BallHog]
+filter=UINT8
 direction=UINT8
 numJumps=UINT8
 bombTime=UINT8
 
 [BarStool]
+filter=UINT8
 height=UINT8
 
 [Batbot]
+filter=UINT8
 direction=UINT8
 
 [Batbrain]
+filter=UINT8
 
 [Beanstalk]
+filter=UINT8
 type=UINT8
 direction=UINT8
 bezCtrlAngle=INT32
@@ -73,60 +105,81 @@ bezCtrlLength=INT32
 forceEnd=BOOL
 
 [BGSwitch]
+filter=UINT8
 size=POSITION
 bgID=UINT8
 
 [BigSqueeze]
+filter=UINT8
 type=VAR
 
 [BladePole]
+filter=UINT8
 
 [Blank Object]
+filter=UINT8
 
 [Blaster]
+filter=UINT8
 direction=UINT8
 
 [Blastoid]
+filter=UINT8
 direction=UINT8
+[Bloominator]
+filter=UINT8
 
 [Bomb]
+filter=UINT8
 direction=UINT8
-planeFilter=VAR
+planeFilter=UINT8
 
 [BouncePlant]
+filter=UINT8
 direction=UINT8
 
 [BoundsMarker]
+filter=UINT8
 type=UINT8
 width=VAR
 vsDisable=BOOL
 offset=VAR
 
 [BreakableWall]
+filter=UINT8
 type=UINT8
+onlyMighty=BOOL
 onlyKnux=BOOL
 priority=VAR
 size=POSITION
 
 [BreakBar]
+filter=UINT8
 orientation=UINT8
 length=UINT16
 
 [Bridge]
+filter=UINT8
 length=UINT8
 burnable=BOOL
 
 [BSS_Collectable]
+filter=UINT8
 
 [BSS_Collected]
+filter=UINT8
 
 [BSS_Horizon]
+filter=UINT8
 
 [BSS_HUD]
+filter=UINT8
 
 [BSS_Message]
+filter=UINT8
 
 [BSS_Palette]
+filter=UINT8
 useStageConfig=BOOL
 paletteID=VAR
 skyAlpha=UINT8
@@ -138,14 +191,18 @@ bgColor2=COLOR
 bgColor3=COLOR
 
 [BSS_Player]
+filter=UINT8
 
 [BSS_Setup]
+filter=UINT8
 paletteID=UINT8
 
 [Bubbler]
+filter=UINT8
 direction=UINT8
 
 [BuckwildBall]
+filter=UINT8
 amplitude=UINT32
 direction=UINT8
 mode=UINT8
@@ -155,47 +212,59 @@ detectSize=POSITION
 respawn=BOOL
 
 [Buggernaut]
+filter=UINT8
 direction=UINT8
 passThrough=BOOL
 
 [Bumpalo]
+filter=UINT8
 direction=UINT8
 ignoreCliffs=BOOL
 
 [Bungee]
+filter=UINT8
 
 [BurningLog]
+filter=UINT8
 timer=VAR
 
 [Button]
+filter=UINT8
 type=VAR
 walkOnto=BOOL
 tag=UINT8
 
 [ButtonDoor]
+filter=UINT8
 buttonTag=VAR
 length=VAR
 duration=VAR
 orientation=UINT8
 
 [BuzzBomber]
+filter=UINT8
 direction=UINT8
 shotRange=UINT8
 
 [BuzzSaw]
+filter=UINT8
 type=VAR
 angle=INT32
 amplitude=POSITION
 speed=VAR
 
 [CableWarp]
+filter=UINT8
 type=VAR
 
 [Cactula]
+filter=UINT8
 
 [Camera]
+filter=UINT8
 
 [Canista]
+filter=UINT8
 direction=UINT8
 triggerMode=UINT8
 detectOffset=POSITION
@@ -204,19 +273,25 @@ shootOffset=VAR
 shootSize=VAR
 
 [Caterkiller]
-planeFilter=VAR
+filter=UINT8
+planeFilter=UINT8
 
 [CaterkillerJr]
+filter=UINT8
 direction=UINT8
 
 [ChaosEmerald]
+filter=UINT8
 type=UINT8
 
 [CheckerBall]
+filter=UINT8
 
 [ChemBubble]
+filter=UINT8
 
 [ChemicalBall]
+filter=UINT8
 type=UINT8
 direction=UINT8
 interval=UINT8
@@ -224,15 +299,18 @@ intervalOffset=UINT8
 master=BOOL
 
 [ChemicalPool]
+filter=UINT8
 type=VAR
 size=POSITION
 
 [Chopper]
+filter=UINT8
 type=UINT8
 direction=UINT8
 charge=BOOL
 
 [CircleBumper]
+filter=UINT8
 hitCount=VAR
 type=VAR
 amplitude=POSITION
@@ -240,44 +318,60 @@ speed=VAR
 angle=INT32
 
 [Clapperboard]
+filter=UINT8
 direction=UINT8
 
 [Clucker]
+filter=UINT8
 direction=UINT8
 delay=UINT16
 
 [CollapsingPlatform]
+filter=UINT8
 size=POSITION
 respawn=BOOL
 targetLayer=UINT16
 type=UINT8
 delay=VAR
 eventOnly=BOOL
+mightyOnly=BOOL
 
 [CollapsingSand]
+filter=UINT8
 size=POSITION
 delay=VAR
 
 [ColorHelpers]
+filter=UINT8
 
 [Competition]
+filter=UINT8
+
+[CompetitionMenu]
+filter=UINT8
 
 [CompetitionSession]
+filter=UINT8
 
 [Constellation]
+filter=UINT8
 direction=UINT8
 shape=UINT8
 
 [ContinuePlayer]
+filter=UINT8
 isPlayer2=BOOL
 
 [ContinueSetup]
+filter=UINT8
 
 [ConveyorBelt]
+filter=UINT8
 size=POSITION
 speed=INT32
 
 [ConveyorPlatform]
+filter=UINT8
 type=VAR
 node=VAR
 childCount=VAR
@@ -286,97 +380,126 @@ intervalOffset=UINT16
 flipCount=UINT16
 
 [ConveyorWheel]
+filter=UINT8
 direction=UINT8
 
 [CorkscrewPath]
+filter=UINT8
 period=VAR
 amplitude=VAR
 angle=VAR
 
 [COverlay]
+filter=UINT8
 
 [CPZ1Intro]
+filter=UINT8
 size=POSITION
 
 [CPZ2Outro]
+filter=UINT8
 size=POSITION
 
 [CPZBoss]
+filter=UINT8
 type=UINT8
 
 [CPZSetup]
+filter=UINT8
 
 [CPZShutter]
+filter=UINT8
 
 [Crabmeat]
+filter=UINT8
 
 [Crane]
+filter=UINT8
 direction=UINT8
 distance=UINT16
 startType=UINT8
 
 [CrashTest]
+filter=UINT8
 direction=UINT8
 length=INT32
 debugParticles=BOOL
 
 [Crate]
+filter=UINT8
 frameID=UINT8
 childCount=VAR
 
 [CreditsSetup]
+filter=UINT8
 
 [CrimsonEye]
+filter=UINT8
 type=VAR
 
 [Current]
+filter=UINT8
 type=VAR
 size=POSITION
 strength=UINT8
 buttonTag=VAR
-planeFilter=VAR
+planeFilter=UINT8
 waterOnly=BOOL
 fbzAchievement=BOOL
 
 [CutsceneHBH]
+filter=UINT8
 direction=UINT8
 characterID=UINT8
 oscillate=BOOL
 hiddenAtStart=BOOL
 
 [CutsceneRules]
+filter=UINT8
 
 [CutsceneSeq]
+filter=UINT8
 
 [Cylinder]
+filter=UINT8
 type=UINT8
 length=VAR
 radius=VAR
 
 [DAControl]
+filter=UINT8
 
 [Dango]
+filter=UINT8
 
 [DASetup]
+filter=UINT8
 
 [DashLift]
+filter=UINT8
 length=VAR
 childCount=VAR
 startOff=VAR
 
 [DBTower]
+filter=UINT8
 
 [DCEvent]
+filter=UINT8
 numChildren=UINT8
 type=UINT8
 
 [DDWrecker]
+filter=UINT8
 
 [Debris]
+filter=UINT8
 
 [DebugMode]
+filter=UINT8
 
 [Decoration]
+filter=UINT8
 type=UINT8
 direction=UINT8
 rotSpeed=VAR
@@ -384,65 +507,89 @@ repeatTimes=POSITION
 repeatSpacing=POSITION
 
 [DemoMenu]
+filter=UINT8
 
 [DERobot]
+filter=UINT8
 aniID=VAR
 frameID=VAR
 
+[DialogRunner]
+filter=UINT8
+
 [DirectorChair]
+filter=UINT8
 type=VAR
 speed=VAR
 size=VAR
 
 [DiveEggman]
+filter=UINT8
 
 [DNARiser]
+filter=UINT8
 height=UINT32
 speed=POSITION
 
 [DoorTrigger]
+filter=UINT8
 orientation=UINT8
 id=UINT8
 
 [Dragonfly]
+filter=UINT8
 dir=UINT8
 dist=UINT8
 speed=UINT8
 
 [DrawHelpers]
+filter=UINT8
 
 [Drillerdroid]
+filter=UINT8
 type=UINT8
 
 [DrillerdroidO]
+filter=UINT8
 type=UINT8
 
 [Dust]
+filter=UINT8
 
 [E3MenuSetup]
+filter=UINT8
 
 [EggJanken]
+filter=UINT8
 
 [EggJankenPart]
+filter=UINT8
 
 [EggLoco]
+filter=UINT8
 
 [Eggman]
+filter=UINT8
 
 [EggPistonsMKII]
+filter=UINT8
 direction=UINT8
 type=UINT8
 
 [EggPrison]
+filter=UINT8
 type=VAR
 
 [EggTower]
+filter=UINT8
 
 [EggTV]
+filter=UINT8
 size=POSITION
 drawOverTV=BOOL
 
 [ElectroMagnet]
+filter=UINT8
 interval=UINT16
 intervalOffset=UINT16
 duration=UINT16
@@ -450,30 +597,56 @@ height=VAR
 shieldRange=VAR
 invisible=BOOL
 
+[EncoreGoodEnd]
+filter=UINT8
+size=POSITION
+
+[EncoreIntro]
+filter=UINT8
+size=POSITION
+
+[EncoreRoute]
+filter=UINT8
+size=POSITION
+
 [ERZGunner]
+filter=UINT8
 
 [ERZKing]
+filter=UINT8
 type=VAR
 
 [ERZMystic]
+filter=UINT8
 
 [ERZOutro]
+filter=UINT8
 size=POSITION
 
 [ERZRider]
+filter=UINT8
 
 [ERZSetup]
+filter=UINT8
 
 [ERZShinobi]
+filter=UINT8
 
 [ERZStart]
+filter=UINT8
 size=POSITION
 
 [EscapeCar]
+filter=UINT8
 
 [Explosion]
+filter=UINT8
+
+[ExtrasMenu]
+filter=UINT8
 
 [Fan]
+filter=UINT8
 type=UINT8
 direction=UINT8
 activation=UINT8
@@ -485,41 +658,55 @@ duration=UINT16
 buttonTag=VAR
 
 [FarPlane]
+filter=UINT8
 size=POSITION
 origin=POSITION
 
 [FBZ1Outro]
+filter=UINT8
 size=POSITION
 
 [FBZFan]
+filter=UINT8
 
 [FBZMissile]
+filter=UINT8
 type=VAR
 interval=UINT8
 intervalOffset=UINT8
 direction=UINT8
 
 [FBZSetup]
+filter=UINT8
 
 [FBZSinkTrash]
+filter=UINT8
 type=VAR
 size=POSITION
 
 [FBZStorm]
+filter=UINT8
 
 [FBZTrash]
+filter=UINT8
 type=VAR
 frameID=VAR
 
+[FernParallax]
+filter=UINT8
+
 [FilmProjector]
+filter=UINT8
 direction=UINT8
 pathMovement=UINT8
 
 [FilmReel]
+filter=UINT8
 pathSize=POSITION
 spinDirection=UINT8
 
 [Fireball]
+filter=UINT8
 type=UINT8
 rotation=INT32
 interval=UINT8
@@ -527,22 +714,27 @@ intervalOffset=UINT8
 groundVel=VAR
 
 [Fireflies]
+filter=UINT8
 
 [Firework]
+filter=UINT8
 distance=INT32
 innerRadius=INT32
 outerRadius=INT32
 
 [Fireworm]
+filter=UINT8
 direction=UINT8
 
 [FlameSpring]
+filter=UINT8
 type=VAR
 force=VAR
 playerAni=UINT8
 offset=UINT8
 
 [Flamethrower]
+filter=UINT8
 orientation=UINT8
 mode=UINT8
 maxDist=UINT32
@@ -552,16 +744,21 @@ intervalOffset=UINT16
 duration=UINT16
 
 [FlasherMKII]
+filter=UINT8
 orientation=UINT8
 
 [FlingRamp]
+filter=UINT8
 
 [Flipper]
+filter=UINT8
 direction=UINT8
 
 [FlowerPod]
+filter=UINT8
 
 [FoldingPlatform]
+filter=UINT8
 childCount=VAR
 interval=UINT16
 intervalOffset=UINT16
@@ -569,25 +766,31 @@ direction=UINT8
 duration=UINT16
 
 [ForceSpin]
+filter=UINT8
 direction=UINT8
 size=VAR
 angle=INT32
 
 [ForceUnstick]
+filter=UINT8
 width=UINT8
 height=UINT8
 breakClimb=BOOL
 
 [FrostThrower]
+filter=UINT8
 interval=UINT16
 intervalOffset=UINT16
 duration=UINT16
 
 [Funnel]
+filter=UINT8
 
 [FXExpandRing]
+filter=UINT8
 
 [FXFade]
+filter=UINT8
 timer=VAR
 speedIn=VAR
 wait=VAR
@@ -599,78 +802,105 @@ overHUD=BOOL
 fadeOutBlack=BOOL
 
 [FXRuby]
+filter=UINT8
 outerRadius=VAR
 fadeWhite=VAR
 fadeBlack=VAR
 waitForTrigger=BOOL
 
 [FXSpinRay]
+filter=UINT8
 
 [FXTrail]
+filter=UINT8
+
+[FXWaveRing]
+filter=UINT8
 
 [Gachapandora]
+filter=UINT8
 
 [GameOver]
+filter=UINT8
 
 [GameProgress]
+filter=UINT8
 
 [GasPlatform]
+filter=UINT8
 type=VAR
 childCount=VAR
 interval=UINT16
 intervalOffset=UINT16
 
 [GenericTrigger]
+filter=UINT8
 size=POSITION
 triggerID=UINT8
 
+[GigaMetal]
+filter=UINT8
+
 [GHZ2Outro]
+filter=UINT8
 size=POSITION
 
 [GHZCutsceneK]
+filter=UINT8
 size=POSITION
 
 [GHZCutsceneST]
+filter=UINT8
 size=POSITION
 
 [GHZSetup]
+filter=UINT8
 
 [GiantPistol]
+filter=UINT8
 direction=UINT8
 
 [Gondola]
+filter=UINT8
 direction=UINT8
 minY=VAR
 maxY=VAR
 boatID=UINT8
 
 [Grabber]
+filter=UINT8
 direction=UINT8
 
 [GreenScreen]
+filter=UINT8
 paraOffset=POSITION
 paraYFactor=VAR
 paraPreview=BOOL
 
 [GymBar]
+filter=UINT8
 type=VAR
 size=VAR
 noSwing=BOOL
 
 [HandLauncher]
+filter=UINT8
 direction=UINT8
 speed=UINT32
 
 [HangConveyor]
+filter=UINT8
 direction=UINT8
 length=UINT32
 
 [HangPoint]
+filter=UINT8
 length=VAR
 speed=UINT8
 direction=UINT8
 
 [Hatch]
+filter=UINT8
 go=UINT8
 subOff1=POSITION
 subOff2=POSITION
@@ -678,42 +908,55 @@ depth=VAR
 dest=VAR
 
 [Hatterkiller]
+filter=UINT8
 
 [HCZ1Intro]
+filter=UINT8
 size=POSITION
 
 [HCZOneWayDoor]
+filter=UINT8
 length=VAR
 duration=VAR
 orientation=UINT8
 detectDirection=UINT8
 
 [HCZSetup]
+filter=UINT8
 
 [HCZSpikeBall]
+filter=UINT8
 
 [HeavyGunner]
+filter=UINT8
 
 [HeavyKing]
+filter=UINT8
 
 [HeavyMystic]
+filter=UINT8
 type=VAR
 
 [HeavyRider]
+filter=UINT8
 type=UINT8
 flags=VAR
 size=VAR
 affectPlayer=BOOL
 
 [HeavyShinobi]
+filter=UINT8
 
 [HiLoSign]
+filter=UINT8
 type=UINT8
 
 [Honkytonk]
+filter=UINT8
 angle=VAR
 
 [Hotaru]
+filter=UINT8
 quality=UINT8
 dist=POSITION
 distX1=VAR
@@ -722,8 +965,10 @@ speed=VAR
 preset=UINT8
 
 [HotaruHiWatt]
+filter=UINT8
 
 [HotaruMKII]
+filter=UINT8
 origin=UINT8
 offset1=POSITION
 offset2=POSITION
@@ -731,11 +976,14 @@ offset3=POSITION
 triggerSize=POSITION
 
 [HPZEmerald]
+filter=UINT8
 type=UINT8
 
 [HUD]
+filter=UINT8
 
 [Ice]
+filter=UINT8
 size=UINT8
 type=UINT8
 subType=UINT8
@@ -744,26 +992,33 @@ bottomSmash=BOOL
 knuxSmash=BOOL
 
 [IceBomba]
+filter=UINT8
 dir=UINT8
 dist=UINT16
 dip=UINT16
 
 [IceSpring]
+filter=UINT8
 type=VAR
 flipFlag=VAR
 onGround=BOOL
 planeFilter=UINT8
 
 [ImageTrail]
+filter=UINT8
 
 [Ink]
+filter=UINT8
 type=UINT8
 
 [InkWipe]
+filter=UINT8
 
 [InvincibleStars]
+filter=UINT8
 
 [InvisibleBlock]
+filter=UINT8
 width=UINT8
 height=UINT8
 planeFilter=VAR
@@ -773,6 +1028,7 @@ timeAttackOnly=BOOL
 noChibi=BOOL
 
 [ItemBox]
+filter=UINT8
 type=VAR
 isFalling=BOOL
 hidden=BOOL
@@ -781,10 +1037,12 @@ planeFilter=VAR
 lrzConvPhys=BOOL
 
 [Iwamodoki]
+filter=UINT8
 direction=UINT8
 lrzConvPhys=BOOL
 
 [JacobsLadder]
+filter=UINT8
 height=UINT32
 interval=VAR
 intervalOffset=VAR
@@ -792,12 +1050,15 @@ duration=VAR
 flip=BOOL
 
 [Jawz]
+filter=UINT8
 triggerDir=UINT8
 
 [Jellygnite]
+filter=UINT8
 direction=UINT8
 
 [JuggleSaw]
+filter=UINT8
 direction=UINT8
 sawDelay=UINT16
 sawSpeed=VAR
@@ -805,11 +1066,14 @@ hasSaw=BOOL
 setID=UINT16
 
 [JunctionWheel]
+filter=UINT8
 
 [Kabasira]
+filter=UINT8
 direction=UINT8
 
 [Kanabun]
+filter=UINT8
 hVel=VAR
 hDist=UINT8
 bobDist=UINT8
@@ -817,20 +1081,26 @@ angleVel=UINT8
 direction=UINT8
 
 [KingAttack]
+filter=UINT8
 
 [KingClaw]
+filter=UINT8
 
 [KleptoMobile]
+filter=UINT8
 type=VAR
 
 [LargeGear]
+filter=UINT8
 rotSpeed=INT32
 rotOffset=INT32
 
 [Launcher]
+filter=UINT8
 direction=UINT8
 
 [LaunchSpring]
+filter=UINT8
 type=UINT8
 rotDir=UINT8
 rotSpeed=UINT8
@@ -839,14 +1109,17 @@ manual=BOOL
 strict=BOOL
 
 [LaundroMobile]
+filter=UINT8
 type=UINT8
 
 [LavaFall]
+filter=UINT8
 interval=UINT16
 intervalOffset=UINT16
 duration=UINT16
 
 [LavaGeyser]
+filter=UINT8
 type=UINT8
 interval=UINT16
 intervalOffset=UINT16
@@ -854,6 +1127,7 @@ duration=UINT16
 force=VAR
 
 [LEDPanel]
+filter=UINT8
 text0=STRING
 text1=STRING
 text2=STRING
@@ -867,49 +1141,67 @@ seq1=STRING
 size=POSITION
 
 [Letterboard]
+filter=UINT8
 controller=BOOL
 letterID=UINT8
 
 [LevelSelect]
+filter=UINT8
 
 [LightBarrier]
+filter=UINT8
 size=VAR
 enabled=BOOL
 
 [LightBulb]
+filter=UINT8
 respawn=BOOL
 priority=VAR
 
 [Localization]
+filter=UINT8
 
 [LocoSmoke]
+filter=UINT8
 
 [LogHelpers]
+filter=UINT8
 
 [LogoSetup]
+filter=UINT8
 
 [LottoBall]
+filter=UINT8
 type=UINT8
 lottoNum=UINT8
 
 [LottoMachine]
+filter=UINT8
 
 [LoveTester]
+filter=UINT8
 
 [LRZ1Outro]
+filter=UINT8
 
 [LRZ1Setup]
+filter=UINT8
 
 [LRZ2Setup]
+filter=UINT8
 
 [LRZ3Cutscene]
+filter=UINT8
 
 [LRZ3OutroK]
+filter=UINT8
 size=POSITION
 
 [LRZ3Setup]
+filter=UINT8
 
 [LRZConvControl]
+filter=UINT8
 triggerMode=UINT8
 buttonTag=VAR
 hitboxSize=POSITION
@@ -917,6 +1209,7 @@ behavior=UINT8
 flipVal=UINT8
 
 [LRZConvDropper]
+filter=UINT8
 triggerMode=UINT8
 interval=VAR
 intervalOffset=VAR
@@ -926,6 +1219,7 @@ seqCount=UINT8
 seqLoop=BOOL
 
 [LRZConveyor]
+filter=UINT8
 direction=UINT8
 slope=VAR
 length=UINT32
@@ -936,12 +1230,15 @@ buttonBehavior=UINT8
 off=BOOL
 
 [LRZConvItem]
+filter=UINT8
 type=UINT8
 
 [LRZConvSwitch]
+filter=UINT8
 calibration=UINT8
 
 [LRZFireball]
+filter=UINT8
 type=UINT8
 rotation=INT32
 interval=UINT16
@@ -949,49 +1246,70 @@ intervalOffset=UINT16
 groundVel=VAR
 
 [LRZRockPile]
+filter=UINT8
 type=UINT8
 delay=UINT16
 debugParticles=BOOL
-knuxOnly=BOOL
 unbreakable=BOOL
 planeFilter=VAR
+onlyKnux=BOOL
+onlyMighty=BOOL
 
 [LRZSpikeBall]
+filter=UINT8
 interval=VAR
 intervalOffset=VAR
 strength=VAR
 
 [LRZSpiral]
+filter=UINT8
 type=UINT8
 height=VAR
 radius=VAR
 
 [MagnetSphere]
+filter=UINT8
 
 [MagPlatform]
+filter=UINT8
 length=VAR
 
 [MagSpikeBall]
+filter=UINT8
+
+[MainMenu]
+filter=UINT8
+
+[ManiaModeMenu]
+filter=UINT8
 
 [MathHelpers]
+filter=UINT8
 
 [MatryoshkaBom]
+filter=UINT8
 direction=UINT8
 planeFilter=VAR
 size=VAR
 
 [MechaBu]
-planeFilter=VAR
+filter=UINT8
+planeFilter=UINT8
 
 [MegaChopper]
+filter=UINT8
 
 [MegaOctus]
+filter=UINT8
 
 [MenuParam]
+filter=UINT8
 
 [MenuSetup]
+filter=UINT8
 
 [MetalArm]
+filter=UINT8
 startAngleA=INT32
 startAngleB=INT32
 endAngleA=INT32
@@ -1001,55 +1319,87 @@ durationB=INT32
 holdDuration=INT32
 
 [MetalSonic]
+filter=UINT8
 
 [MeterDroid]
+filter=UINT8
 
 [MicDrop]
+filter=UINT8
 distance=UINT16
 
 [Mine]
+filter=UINT8
+
+[MMZ2Outro]
+filter=UINT8
+
+[MMZLighning]
+filter=UINT8
 
 [MMZSetup]
+filter=UINT8
 
 [MMZWheel]
+filter=UINT8
 amplitude=UINT32
 childCount=UINT8
 speed=VAR
 motionType=UINT8
 
 [MonarchBG]
+filter=UINT8
+
+[MonarchPlans]
+filter=UINT8
 
 [MonkeyDude]
+filter=UINT8
 nummoves=VAR
 
 [Motobug]
+filter=UINT8
+
+[MSBomb]
+filter=UINT8
 
 [MSFactory]
+filter=UINT8
 
 [MSHologram]
+filter=UINT8
 
 [MSOrb]
+filter=UINT8
 
 [MSPanel]
+filter=UINT8
 
 [MSZ1KIntro]
+filter=UINT8
 size=POSITION
 
 [MSZ2Cutscene]
+filter=UINT8
 size=POSITION
 
 [MSZCutsceneK]
+filter=UINT8
 size=POSITION
 
 [MSZCutsceneST]
+filter=UINT8
 size=POSITION
 
 [MSZSetup]
+filter=UINT8
 
 [MSZSpotlight]
+filter=UINT8
 color=UINT8
 
 [Music]
+filter=UINT8
 trackFile=STRING
 soundTestTitle=STRING
 trackID=VAR
@@ -1057,47 +1407,66 @@ trackLoop=UINT32
 playOnLoad=BOOL
 
 [Newspaper]
+filter=UINT8
 node=VAR
 childCount=VAR
 
 [Newtron]
+filter=UINT8
 type=UINT8
 direction=UINT8
 
+[NoSwap]
+filter=UINT8
+
 [Octus]
+filter=UINT8
 direction=UINT8
 
 [OneWayDoor]
+filter=UINT8
 direction=UINT8
 
 [OOZ1Outro]
+filter=UINT8
 size=POSITION
 
 [OOZFlames]
+filter=UINT8
 
 [OOZSetup]
+filter=UINT8
 type=UINT8
 
 [Options]
+filter=UINT8
+
+[OptionsMenu]
+filter=UINT8
 
 [Orbinaut]
+filter=UINT8
 direction=UINT8
-planeFilter=VAR
+planeFilter=UINT8
 fireOrbs=BOOL
 
 [OrbitSpike]
+filter=UINT8
 direction=UINT8
 amplitude=POSITION
 offset=UINT8
 
 [PaintingEyes]
+filter=UINT8
 
 [PaperRoller]
+filter=UINT8
 direction=UINT8
 length=VAR
 angle=VAR
 
 [ParallaxSprite]
+filter=UINT8
 aniID=UINT8
 attribute=UINT8
 parallaxFactor=POSITION
@@ -1106,15 +1475,54 @@ loopPoint=POSITION
 hiddenAtStart=BOOL
 
 [ParticleHelpers]
+filter=UINT8
 
 [PathInverter]
+filter=UINT8
 type=UINT8
 
 [PauseMenu]
+filter=UINT8
+
+[PBL_Bumper]
+filter=UINT8
+
+[PBL_Setup]
+filter=UINT8
+
+[PBL_Camera]
+filter=UINT8
+
+[PBL_Player]
+filter=UINT8
+
+[PBL_Flipper]
+filter=UINT8
+retractable=BOOL
+
+[PBL_Ring]
+filter=UINT8
+height=VAR
+
+[PBL_Sector]
+filter=UINT8
+size=POSITION
+
+[PBL_HUD]
+filter=UINT8
+
+[PBL_Crane]
+filter=UINT8
+
+[PBL_TargetBumper]
+filter=UINT8
+angle=VAR
 
 [Pendulum]
+filter=UINT8
 
 [PetalPile]
+filter=UINT8
 leafPattern=INT8
 tileLayer=INT8
 pileSize=POSITION
@@ -1122,29 +1530,40 @@ maxSpeed=POSITION
 emitterMode=BOOL
 
 [PhantomEgg]
+filter=UINT8
 type=VAR
 
 [PhantomGunner]
+filter=UINT8
 
 [PhantomHand]
+filter=UINT8
 
 [PhantomKing]
+filter=UINT8
 type=VAR
 
 [PhantomMissile]
+filter=UINT8
 
 [PhantomMystic]
+filter=UINT8
 
 [PhantomRider]
+filter=UINT8
 
 [PhantomRuby]
+filter=UINT8
 sfx=UINT8
 
 [PhantomShield]
+filter=UINT8
 
 [PhantomShinobi]
+filter=UINT8
 
 [PimPom]
+filter=UINT8
 type=VAR
 color=UINT8
 direction=UINT8
@@ -1159,10 +1578,12 @@ gap=UINT8
 numChildren=UINT8
 
 [Pinata]
+filter=UINT8
 respawn=BOOL
 priority=VAR
 
 [Piston]
+filter=UINT8
 type=VAR
 reverse=BOOL
 size=UINT8
@@ -1172,16 +1593,20 @@ intervalOffset=UINT16
 distance=VAR
 
 [PKingAttack]
+filter=UINT8
 
 [PlaneSeeSaw]
+filter=UINT8
 
 [PlaneSwitch]
+filter=UINT8
 flags=VAR
 size=VAR
 angle=INT32
 onPath=BOOL
 
 [Platform]
+filter=UINT8
 type=VAR
 amplitude=POSITION
 speed=VAR
@@ -1193,6 +1618,7 @@ childCount=VAR
 angle=INT32
 
 [PlatformControl]
+filter=UINT8
 nodeCount=VAR
 childCount=VAR
 speed=VAR
@@ -1201,34 +1627,43 @@ type=UINT8
 buttonTag=VAR
 
 [PlatformNode]
+filter=UINT8
 nodeFlag=VAR
 
 [Player]
+filter=UINT8
 characterID=VAR
 
 [PlayerHelpers]
+filter=UINT8
 
 [PlayerProbe]
+filter=UINT8
 direction=UINT8
 size=VAR
 angle=INT32
 
 [PohBee]
+filter=UINT8
 direction=UINT8
 spikeCount=UINT8
 amplitude=POSITION
-planeFilter=VAR
+planeFilter=UINT8
 
 [Pointdexter]
+filter=UINT8
 direction=UINT8
 
 [PopcornKernel]
+filter=UINT8
 
 [PopcornMachine]
+filter=UINT8
 type=UINT8
 height=UINT8
 
 [PopOut]
+filter=UINT8
 direction=UINT8
 orientation=UINT8
 tag=UINT8
@@ -1236,12 +1671,14 @@ manualTrigger=BOOL
 delay=VAR
 
 [Press]
+filter=UINT8
 size=UINT16
 speed=UINT32
 offTop=VAR
 offBottom=VAR
 
 [PrintBlock]
+filter=UINT8
 childCount=VAR
 interval=UINT16
 intervalOffset=UINT16
@@ -1249,24 +1686,32 @@ duration=UINT16
 letter=UINT8
 
 [Projectile]
+filter=UINT8
 
 [Propeller]
+filter=UINT8
 fanEnabled=BOOL
 
 [PropellerShaft]
+filter=UINT8
 size=VAR
 
 [PSZ1Setup]
+filter=UINT8
 
 [PSZ2Intro]
+filter=UINT8
 size=POSITION
 
 [PSZ2Outro]
+filter=UINT8
 size=POSITION
 
 [PSZ2Setup]
+filter=UINT8
 
 [PSZDoor]
+filter=UINT8
 orientation=UINT8
 open=BOOL
 speed=VAR
@@ -1274,12 +1719,15 @@ id=UINT8
 automatic=VAR
 
 [PSZEggman]
+filter=UINT8
 
 [PSZLauncher]
+filter=UINT8
 direction=UINT8
 power=UINT8
 
 [PullChain]
+filter=UINT8
 type=VAR
 walkOnto=BOOL
 tag=UINT8
@@ -1287,50 +1735,74 @@ length=UINT32
 decorMode=BOOL
 
 [PullSwitch]
+filter=UINT8
 
 [PushSpring]
+filter=UINT8
 type=UINT8
 direction=UINT8
 
 [PuyoAI]
+filter=UINT8
 
 [PuyoAttack]
+filter=UINT8
 
 [PuyoBean]
+filter=UINT8
 
 [PuyoGame]
+filter=UINT8
 
 [PuyoIndicator]
+filter=UINT8
 playerID=UINT8
 
 [PuyoLabel]
+filter=UINT8
 listID=VAR
 frame=VAR
 
 [PuyoLevelSelect]
+filter=UINT8
 playerID=VAR
 
 [PuyoMatch]
+filter=UINT8
 playerID=VAR
 
 [PuyoScore]
+filter=UINT8
 playerID=VAR
 counter=BOOL
 
 [Rattlekiller]
+filter=UINT8
 direction=UINT8
 length=VAR
 
 [Reagent]
+filter=UINT8
 
 [Redz]
+filter=UINT8
 direction=UINT8
+
+[ReplayDB]
+filter=UINT8
+
+[ReplayRecorder]
+filter=UINT8
 
 [Rexon]
+filter=UINT8
 direction=UINT8
 noMove=BOOL
+[Rhinobot]
+filter=UINT8
 
 [Ring]
+filter=UINT8
 type=VAR
 planeFilter=VAR
 moveType=VAR
@@ -1339,25 +1811,31 @@ speed=VAR
 angle=INT32
 
 [RingField]
+filter=UINT8
 size=POSITION
 frequency=VAR
 fluctuation=VAR
 running=BOOL
 
 [RisingLava]
+filter=UINT8
 size=POSITION
 offset=POSITION
 limit=VAR
 
 [RockDrill]
+filter=UINT8
 lockCamera=BOOL
 
 [RockemSockem]
+filter=UINT8
 
 [RollerMKII]
+filter=UINT8
 direction=UINT8
 
 [RotatingSpikes]
+filter=UINT8
 pivotRadius=VAR
 spikeRadius=VAR
 spikeCount=VAR
@@ -1366,6 +1844,7 @@ angleOffset=VAR
 priority=VAR
 
 [RotatingStair]
+filter=UINT8
 mode=VAR
 amplitude=POSITION
 childCount=VAR
@@ -1373,52 +1852,70 @@ direction=UINT8
 oscOff=UINT16
 
 [RPlaneShifter]
+filter=UINT8
 height=UINT32
 flags=UINT8
 
 [RTeleporter]
+filter=UINT8
 
 [RubyPortal]
+filter=UINT8
 
 [SaveGame]
+filter=UINT8
 
 [Scarab]
+filter=UINT8
 direction=UINT8
 amplitude=INT32
 childCount=UINT8
-planeFilter=VAR
+planeFilter=UINT8
 
 [ScoreBonus]
+filter=UINT8
 
 [ScrewMobile]
+filter=UINT8
+
+[SchrodingersCapsule]
 
 [SDashWheel]
+filter=UINT8
 tag=UINT8
 direction=UINT8
 
 [SeeSaw]
+filter=UINT8
 side=UINT8
 
 [SeltzerBottle]
+filter=UINT8
 direction=UINT8
 sprayTime=VAR
 
 [SeltzerWater]
+filter=UINT8
 
 [SentryBug]
+filter=UINT8
 speed=UINT8
 amplitude=POSITION
 
 [Shield]
+filter=UINT8
 
 [Shiversaw]
+filter=UINT8
 
 [ShopWindow]
+filter=UINT8
 size=POSITION
 shatter=BOOL
 silhouette=BOOL
 
 [Shuriken]
+filter=UINT8
 direction=UINT8
 delay=UINT16
 timerMode=BOOL
@@ -1427,14 +1924,17 @@ intervalOffset=UINT16
 timerGroup=UINT8
 
 [Shutterbug]
+filter=UINT8
 snaps=UINT8
 passThrough=BOOL
 range=POSITION
 
 [SideBarrel]
+filter=UINT8
 timeAttackFreeze=BOOL
 
 [SignPost]
+filter=UINT8
 type=UINT8
 vsBoundsSize=POSITION
 vsBoundsOffset=POSITION
@@ -1442,25 +1942,33 @@ vsExtendTop=VAR
 vsExtendBottom=VAR
 
 [SilverSonic]
+filter=UINT8
 
 [SizeLaser]
+filter=UINT8
 type=UINT8
 orientation=UINT8
 extend=VAR
 
 [SkyTeleporter]
+filter=UINT8
 
 [Smog]
+filter=UINT8
 
 [Snowflakes]
+filter=UINT8
 
 [Sol]
+filter=UINT8
 direction=UINT8
 fireOrbs=BOOL
 
 [Soundboard]
+filter=UINT8
 
 [SP500]
+filter=UINT8
 len=VAR
 height=VAR
 offL=VAR
@@ -1472,67 +1980,82 @@ srcM=POSITION
 srcY=POSITION
 
 [SP500MkII]
+filter=UINT8
 start=UINT8
 yDir=UINT8
 printRows=UINT32
 length=UINT32
 
 [SparkRail]
+filter=UINT8
 size=POSITION
 
 [Spear]
+filter=UINT8
 orientation=UINT8
 interval=UINT32
 intervalOffset=UINT32
 duration=UINT32
 
 [SpearBlock]
+filter=UINT8
 spearDir=UINT8
 
 [SpecialClear]
+filter=UINT8
 
 [SpecialRing]
+filter=UINT8
 id=VAR
 planeFilter=VAR
 
 [SpeedBooster]
+filter=UINT8
 direction=UINT8
 speed=UINT8
 
 [SpeedGate]
+filter=UINT8
 id=VAR
 timer=VAR
 prize=VAR
 direction=UINT8
 
 [SpiderMobile]
+filter=UINT8
 origin=POSITION
 
 [SpikeCorridor]
+filter=UINT8
 colWidth=INT8
 rowHeight=INT8
 yOffset=INT32
 
 [SpikeCrusher]
+filter=UINT8
 childCount=VAR
 startDir=VAR
 
 [SpikeFlail]
+filter=UINT8
 chainLength=UINT8
 phase512=UINT16
 
 [SpikeLog]
+filter=UINT8
 frame=UINT8
 
 [Spikes]
+filter=UINT8
 type=VAR
 moving=BOOL
 count=UINT8
 stagger=UINT8
 timer=UINT8
-planeFilter=VAR
+planeFilter=UINT8
 
 [SpinBooster]
+filter=UINT8
 direction=UINT8
 autoGrip=UINT8
 bias=UINT8
@@ -1544,56 +2067,75 @@ playSound=BOOL
 allowTubeInput=BOOL
 
 [SpinSign]
+filter=UINT8
 type=UINT8
 
 [Spiny]
+filter=UINT8
 type=UINT8
 direction=UINT8
 
 [SpiralPlatform]
+filter=UINT8
 offRange=POSITION
 speed=VAR
 childCount=VAR
 
 [Splats]
+filter=UINT8
 bounceCount=UINT8
 direction=UINT8
 numActive=UINT8
 minDelay=UINT16
 
 [Spring]
+filter=UINT8
 type=VAR
 flipFlag=VAR
 onGround=BOOL
 planeFilter=UINT8
 
 [Springboard]
+filter=UINT8
 direction=UINT8
 force=VAR
 
 [SPZ1Intro]
+filter=UINT8
 size=POSITION
 
 [SPZ1Setup]
+filter=UINT8
 
 [SPZ2Outro]
+filter=UINT8
 size=POSITION
 
 [SPZ2Setup]
+filter=UINT8
 
 [SSZ1Intro]
+filter=UINT8
 size=POSITION
 
 [SSZ1Outro]
+filter=UINT8
 size=POSITION
 
 [SSZ1Setup]
+filter=UINT8
 
 [SSZ2Setup]
+filter=UINT8
 
 [SSZ3Cutscene]
+filter=UINT8
+
+[SSZEggman]
+filter=UINT8
 
 [SSZSpikeBall]
+filter=UINT8
 type=UINT8
 direction=UINT8
 interval=UINT16
@@ -1602,6 +2144,7 @@ speed=VAR
 dist=VAR
 
 [SSZSpotlight]
+filter=UINT8
 color=UINT8
 size=UINT8
 drawFlag=UINT8
@@ -1610,72 +2153,94 @@ offset=UINT8
 flashSpeed=UINT8
 
 [Staircase]
+filter=UINT8
 direction=UINT8
 type=UINT8
 bumpable=BOOL
 
 [Stalactite]
+filter=UINT8
 
 [StarPost]
+filter=UINT8
 id=VAR
 direction=UINT8
 vsRemove=BOOL
 
 [Stegway]
+filter=UINT8
 direction=UINT8
 
 [StickyPlatform]
+filter=UINT8
 type=VAR
 amplitude=POSITION
 speed=VAR
 oscillate=BOOL
 
+[SummaryEmerald]
+filter=UINT8
+emeraldID=VAR
+
 [SuperSparkle]
+filter=UINT8
 
 [Sweep]
+filter=UINT8
 direction=UINT8
 
 [SwingRope]
+filter=UINT8
 ropeSize=UINT8
 angleOffset=VAR
 
 [SwitchDoor]
+filter=UINT8
 go=VAR
 reversible=BOOL
 
 [Syringe]
+filter=UINT8
 type=VAR
 tag=UINT8
 
 [TAEmerald]
+filter=UINT8
 color=UINT8
 
 [TargetBumper]
+filter=UINT8
 type=VAR
 hitCount=VAR
 direction=UINT8
 
 [Technosqueek]
+filter=UINT8
 type=UINT8
 direction=UINT8
 speed=UINT8
 distance=UINT16
 
 [TeeterTotter]
+filter=UINT8
 color=UINT8
 length=UINT32
 
 [TetherBall]
+filter=UINT8
 type=UINT8
 chainCount=UINT8
 angleStart=VAR
 angleEnd=VAR
 
 [ThanksSetup]
+filter=UINT8
 
 [ThoughtBubble]
+filter=UINT8
 
 [TilePlatform]
+filter=UINT8
 type=VAR
 amplitude=POSITION
 speed=VAR
@@ -1686,8 +2251,10 @@ size=POSITION
 angle=INT32
 
 [TimeAttackData]
+filter=UINT8
 
 [TimeAttackGate]
+filter=UINT8
 finishLine=BOOL
 extendTop=VAR
 extendBottom=VAR
@@ -1695,12 +2262,18 @@ boundsSize=POSITION
 boundsOffset=POSITION
 topBoundary=BOOL
 
+[TimeAttackMenu]
+filter=UINT8
+
 [TimePost]
+filter=UINT8
 type=UINT8
 
 [TimeTravelSetup]
+filter=UINT8
 
 [TippingPlatform]
+filter=UINT8
 childCount=VAR
 interval=UINT8
 intervalOffset=UINT8
@@ -1708,48 +2281,65 @@ duration=UINT8
 bossID=UINT8
 
 [Title3DSprite]
+filter=UINT8
 frame=VAR
 
 [TitleBG]
+filter=UINT8
 type=VAR
 
 [TitleCard]
+filter=UINT8
 zoneName=STRING
 actID=UINT8
 
 [TitleLogo]
+filter=UINT8
 type=VAR
 
 [TitleSetup]
+filter=UINT8
 
 [TitleSonic]
+filter=UINT8
 
 [TMZ1Outro]
+filter=UINT8
 size=POSITION
 
 [TMZ1Setup]
+filter=UINT8
 
 [TMZ2Outro]
+filter=UINT8
 
 [TMZ2Setup]
+filter=UINT8
 
 [TMZ3Setup]
+filter=UINT8
 
 [TMZAlert]
+filter=UINT8
 
 [TMZBarrier]
+filter=UINT8
 type=UINT8
 warpTag=UINT8
 iD=UINT8
 
 [TMZCable]
+filter=UINT8
 cableID=VAR
 
 [TMZFlames]
+filter=UINT8
 
 [Tornado]
+filter=UINT8
 
 [TornadoPath]
+filter=UINT8
 type=VAR
 targetSpeed=VAR
 timer=VAR
@@ -1759,36 +2349,49 @@ size=POSITION
 forceSpeed=VAR
 
 [Toxomister]
+filter=UINT8
 direction=UINT8
 
 [TransportTube]
+filter=UINT8
 type=UINT8
 dirMask=UINT8
 
 [TryAgain]
+filter=UINT8
+
+[TryAgainE]
+filter=UINT8
 
 [TTCutscene]
+filter=UINT8
 size=POSITION
 
 [TubeSpring]
+filter=UINT8
 type=VAR
 flipFlag=VAR
 
 [Tubinaut]
+filter=UINT8
 distance=UINT16
 
 [Tuesday]
+filter=UINT8
 type=UINT8
 links=UINT8
 
 [Turbine]
+filter=UINT8
 type=UINT8
 
 [TurboSpiker]
+filter=UINT8
 type=VAR
 direction=UINT8
 
 [TurboTurtle]
+filter=UINT8
 stepCount=UINT16
 initialSide=UINT8
 stationary=BOOL
@@ -1802,79 +2405,103 @@ rightFanStrength=UINT32
 rightFanLength=UINT32
 
 [Turntable]
+filter=UINT8
 direction=UINT8
 type=UINT8
 angleVel=INT32
 
 [TurretSwitch]
+filter=UINT8
 tag=UINT8
 direction=UINT8
 
 [TVFlyingBattery]
+filter=UINT8
 
 [TVPole]
+filter=UINT8
 length=UINT16
 
 [TVVan]
+filter=UINT8
 type=UINT8
 
 [TwistedTubes]
+filter=UINT8
 height=UINT8
 
 [TwistingDoor]
+filter=UINT8
 type=VAR
 buttonTag=VAR
 direction=UINT8
 close=BOOL
 
 [TwistingSlide]
+filter=UINT8
 type=UINT8
 endLen=VAR
 direction=UINT8
 
 [UberCaterkiller]
+filter=UINT8
 
 [UFO_Camera]
+filter=UINT8
 
 [UFO_Circuit]
+filter=UINT8
 mode=UINT8
+throttle=UINT8
 startNode=BOOL
 reverse=BOOL
 
 [UFO_Decoration]
+filter=UINT8
 type=VAR
 angle=VAR
 size=VAR
 
 [UFO_Dust]
+filter=UINT8
 height=VAR
 
 [UFO_HUD]
+filter=UINT8
 
 [UFO_ItemBox]
+filter=UINT8
 type=VAR
 height=VAR
 
 [UFO_Message]
+filter=UINT8
 
 [UFO_Plasma]
+filter=UINT8
 
 [UFO_Player]
+filter=UINT8
 machQuota1=VAR
 machQuota2=VAR
 machQuota3=VAR
 startingRings=VAR
 
 [UFO_Ring]
+filter=UINT8
 height=VAR
 
 [UFO_Setup]
+filter=UINT8
 
 [UFO_Shadow]
+filter=UINT8
 
 [UFO_SpeedLines]
+filter=UINT8
 
 [UFO_Sphere]
+filter=UINT8
 type=VAR
 behavior=VAR
 height=VAR
@@ -1884,15 +2511,19 @@ matAngle=POSITION
 amplitude=POSITION
 
 [UFO_Springboard]
+filter=UINT8
 angle=VAR
 rampCount=UINT8
 
 [UFO_Water]
+filter=UINT8
 
 [UIBackground]
+filter=UINT8
 type=VAR
 
 [UIButton]
+filter=UINT8
 disabled=BOOL
 size=POSITION
 listID=VAR
@@ -1902,27 +2533,40 @@ choiceCount=VAR
 choiceDir=UINT8
 invisible=BOOL
 assignsP1=BOOL
+freeBindP2=BOOL
 transition=BOOL
 stopMusic=BOOL
 
 [UIButtonLabel]
+filter=UINT8
 type=UINT8
 listID=VAR
 frameID=VAR
 
 [UIButtonPrompt]
+filter=UINT8
 promptID=VAR
 buttonID=VAR
+headingAnchor=UINT8
+
+[UICarousel]
+filter=UINT8
+shift=POSITION
+clipSize=POSITION
+clipOffset=POSITION
 
 [UICharButton]
+filter=UINT8
 disabled=BOOL
 characterID=UINT8
 
 [UIChoice]
+filter=UINT8
 disabled=BOOL
 size=POSITION
 listID=VAR
 frameID=VAR
+noText=BOOL
 auxIcon=BOOL
 auxListID=VAR
 auxFrameID=VAR
@@ -1930,6 +2574,7 @@ align=VAR
 arrowWidth=VAR
 
 [UIControl]
+filter=UINT8
 tag=STRING
 parentTag=STRING
 activeOnLoad=BOOL
@@ -1941,8 +2586,11 @@ startingID=UINT8
 size=POSITION
 cameraOffset=POSITION
 scrollSpeed=POSITION
+noClamp=BOOL
+noWrap=BOOL
 
 [UICreditsText]
+filter=UINT8
 text=STRING
 tag=STRING
 listID=VAR
@@ -1950,30 +2598,41 @@ isHeading=BOOL
 hasShape=BOOL
 
 [UIDialog]
+filter=UINT8
+
+[UIDiorama]
+filter=UINT8
 
 [UIHeading]
+filter=UINT8
 headingID=VAR
 
 [UIInfoLabel]
+filter=UINT8
 size=POSITION
 text=STRING
 
 [UIKeyBinder]
+filter=UINT8
 disabled=BOOL
 type=UINT8
 inputID=UINT8
 
 [UILeaderboard]
+filter=UINT8
 disabled=BOOL
 
 [UIMedallionPanel]
+filter=UINT8
 
 [UIModeButton]
+filter=UINT8
 disabled=BOOL
 buttonID=VAR
 stopMusic=BOOL
 
 [UIOptionPanel]
+filter=UINT8
 panelSize=VAR
 topListID=VAR
 topFrameID=VAR
@@ -1983,29 +2642,55 @@ botAlignRight=BOOL
 botHidden=BOOL
 
 [UIPicture]
+filter=UINT8
 listID=VAR
 frameID=VAR
 tag=VAR
 zonePalette=BOOL
 zoneID=UINT8
 
+[UIPopover]
+filter=UINT8
+
+[UIRankButton]
+filter=UINT8
+
+[UIReplayCarousel]
+filter=UINT8
+shift=POSITION
+
 [UIResPicker]
+filter=UINT8
 disabled=BOOL
 size=POSITION
 align=VAR
 arrowWidth=VAR
 
 [UISaveSlot]
+filter=UINT8
 disabled=BOOL
 type=VAR
 slotID=VAR
+encoreMode=BOOL
+debugEncoreDraw=BOOL
+dCharPoint=UINT8
+dCharPartner=UINT8
+dCharStock1=UINT8
+dCharStock2=UINT8
+dCharStock3=UINT8
+
+[UIShifter]
+filter=UINT8
+shift=POSITION
 
 [UISlider]
+filter=UINT8
 disabled=BOOL
 listID=VAR
 frameID=VAR
 
 [UISubHeading]
+filter=UINT8
 size=POSITION
 listID=VAR
 frameID=VAR
@@ -2013,13 +2698,18 @@ align=VAR
 offset=VAR
 
 [UITAZoneModule]
+filter=UINT8
 disabled=BOOL
 zoneID=UINT8
 text1=STRING
 text2=STRING
 debugExpand=BOOL
 
+[UITABanner]
+filter=UINT8
+
 [UIText]
+filter=UINT8
 text=STRING
 tag=STRING
 selectable=BOOL
@@ -2029,12 +2719,16 @@ data0=VAR
 data1=VAR
 data2=VAR
 data3=VAR
+highlighted=BOOL
 
 [UITransition]
+filter=UINT8
 
 [UIUsernamePopup]
+filter=UINT8
 
 [UIVideo]
+filter=UINT8
 videoFile1=STRING
 videoFile2=STRING
 audioFile=STRING
@@ -2043,13 +2737,16 @@ stageListCategory=STRING
 stageListName=STRING
 
 [UIVsCharSelector]
+filter=UINT8
 disabled=BOOL
 playerID=UINT8
 
 [UIVsResults]
+filter=UINT8
 disabled=BOOL
 playerID=UINT8
 numRows=VAR
+trophyCount=VAR
 row0Label=UINT8
 row1Label=UINT8
 row2Label=UINT8
@@ -2078,6 +2775,7 @@ row11Highlight=BOOL
 row12Highlight=BOOL
 
 [UIVsRoundPicker]
+filter=UINT8
 disabled=BOOL
 size=POSITION
 align=VAR
@@ -2086,6 +2784,7 @@ val=VAR
 maxVal=VAR
 
 [UIVsScoreboard]
+filter=UINT8
 offset=POSITION
 size=POSITION
 p1Score=UINT8
@@ -2094,6 +2793,7 @@ showWinner=BOOL
 winnerID=UINT8
 
 [UIVsZoneButton]
+filter=UINT8
 disabled=BOOL
 zoneID=VAR
 act=VAR
@@ -2101,37 +2801,46 @@ xOut=BOOL
 obfuscate=BOOL
 
 [UIWaitSpinner]
+filter=UINT8
 
 [UIWidgets]
+filter=UINT8
 
 [UIWinSize]
+filter=UINT8
 disabled=BOOL
 size=POSITION
 align=VAR
 arrowWidth=VAR
 
 [UncurlPlant]
+filter=UINT8
 direction=UINT8
 
 [Valve]
+filter=UINT8
 direction=UINT8
 
 [VanishPlatform]
+filter=UINT8
 childCount=VAR
 interval=UINT16
 intervalOffset=UINT16
 duration=UINT16
 
 [Vultron]
+filter=UINT8
 type=UINT8
 dist=UINT16
 direction=UINT8
 
 [WalkerLegs]
+filter=UINT8
 direction=UINT8
 steps=UINT16
 
 [WallBumper]
+filter=UINT8
 type=VAR
 size=VAR
 direction=UINT8
@@ -2139,9 +2848,11 @@ reverse=BOOL
 destructible=BOOL
 
 [WallCrawl]
+filter=UINT8
 direction=UINT8
 
 [WarpDoor]
+filter=UINT8
 go=VAR
 width=UINT32
 height=UINT32
@@ -2157,6 +2868,7 @@ warpToCenter=BOOL
 forcePlayerState=UINT8
 
 [Water]
+filter=UINT8
 type=VAR
 numDuds=UINT8
 size=POSITION
@@ -2168,37 +2880,48 @@ g=UINT8
 b=UINT8
 priority=UINT8
 destroyOnTrigger=BOOL
+[WaterfallSound]
+filter=UINT8
+size=POSITION
 
 [WaterGush]
+filter=UINT8
 orientation=UINT8
 length=UINT32
 speed=INT32
 
 [WeatherMobile]
+filter=UINT8
 type=VAR
 
 [WeatherTV]
+filter=UINT8
 
 [Whirlpool]
+filter=UINT8
 angVel=VAR
 yVel=VAR
 size=POSITION
 
 [Wisp]
+filter=UINT8
 direction=UINT8
 
 [WoodChipper]
+filter=UINT8
 direction=UINT8
 size=UINT16
 speed=VAR
 
 [Woodrow]
+filter=UINT8
 type=UINT8
 direction=UINT8
 distUp=VAR
 distDown=VAR
 
 [YoyoPulley]
+filter=UINT8
 direction=UINT8
 pullDir=UINT8
 angle=VAR
@@ -2206,7 +2929,9 @@ length=VAR
 speed=VAR
 
 [ZipLine]
+filter=UINT8
 angle=INT32
 length=VAR
 
 [Zone]
+filter=UINT8

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can hold **Ctrl** and/or **Shift** to mirror/flip the placed tile.
 You can choose which properties the placed tiles will have by clicking on the checkboxes below the tiles selection window.
 
 ## Plus Compatibility
-With help from [SuperSonic16](https://github.com/thesupersonic16) and [Axanery](https://github.com/Axanery), we've got some support for Plus.
+With help from [SuperSonic16](https://github.com/thesupersonic16) and [Axanery](https://www.youtube.com/channel/UCIsXoOHibP8wpjcha3bSbMQ), we've got some support for Plus.
 Lots still do here!
 
 ## New Features

--- a/README.md
+++ b/README.md
@@ -40,7 +40,12 @@ You can remove tile by doing the same with the right mouse button.
 You can hold **Ctrl** and/or **Shift** to mirror/flip the placed tile.  
 You can choose which properties the placed tiles will have by clicking on the checkboxes below the tiles selection window.
 
+## Plus Compatibility
+With help from [SuperSonic16](https://github.com/thesupersonic16) and [Axanery](https://github.com/Axanery), we've got some support for Plus.
+Lots still do here!
+
 ## New Features
+
 * In-editor visual entities! You can see spikes, rings and many more things! (Contributed by [supersonic16](https://github.com/thesupersonic16))
 * Flip a collection of selected tiles as one cohesive block.
 * Paste new tiles and entities next to the mouse cursor, not the top left.

--- a/RSDKv5/AttributeValue.cs
+++ b/RSDKv5/AttributeValue.cs
@@ -195,5 +195,36 @@ namespace RSDKv5
                     break;
             }
         }
+
+        public override string ToString()
+        {
+            switch (Type)
+            {
+                case AttributeTypes.UINT8:
+                    return value_uint8.ToString();
+                case AttributeTypes.UINT16:
+                    return value_uint16.ToString();
+                case AttributeTypes.UINT32:
+                    return value_uint32.ToString();
+                case AttributeTypes.INT8:
+                    return value_int8.ToString();
+                case AttributeTypes.INT16:
+                    return value_int16.ToString();
+                case AttributeTypes.INT32:
+                    return value_int32.ToString();
+                case AttributeTypes.VAR:
+                    return value_var.ToString();
+                case AttributeTypes.BOOL:
+                    return value_bool.ToString();
+                case AttributeTypes.STRING:
+                    return value_string.ToString();
+                case AttributeTypes.POSITION:
+                    return value_position.ToString();
+                case AttributeTypes.COLOR:
+                    return value_color.ToString();
+                default:
+                    return "Unhandled Type for ToString()";
+            }
+        }
     }
 }

--- a/RSDKv5/GIF.cs
+++ b/RSDKv5/GIF.cs
@@ -96,7 +96,7 @@ namespace RSDKv5
         {
             if (null == _texturesCache) return;
             foreach (Texture texture in _texturesCache.Values)
-                texture.Dispose();
+                texture?.Dispose();
             _texturesCache.Clear();
         }
 
@@ -117,7 +117,7 @@ namespace RSDKv5
             _bitmap.Dispose();
             DisposeTextures();
             foreach (Bitmap b in _bitmapCache.Values)
-                b.Dispose();
+                b?.Dispose();
             _bitmapCache.Clear();
         }
 

--- a/RSDKv5/GameConfig.cs
+++ b/RSDKv5/GameConfig.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.IO;
+using System.Linq;
 
 namespace RSDKv5
 {
@@ -93,19 +91,21 @@ namespace RSDKv5
 
         public List<ConfigurableMemoryEntry> ConfigMemory = new List<ConfigurableMemoryEntry>();
 
-        public GameConfig(string filename) : this(new Reader(filename))
+        public GameConfig(string filename)
         {
-
+            using (var reader = new Reader(filename))
+                Read(reader);
         }
 
-        public GameConfig(Stream stream) : this(new Reader(stream))
+        public GameConfig(Stream stream)
         {
-
+            using (var reader = new Reader(stream))
+                Read(reader);
         }
 
-        private GameConfig(Reader reader)
+        private void Read(Reader reader)
         {
-            base.ReadMagic(reader);
+            ReadMagic(reader);
 
             GameName = reader.ReadRSDKString();
             GameSubname = reader.ReadRSDKString();
@@ -116,7 +116,7 @@ namespace RSDKv5
             StartSceneCategoryIndex = reader.ReadByte();
             StartSceneIndex = reader.ReadUInt16();
 
-            base.ReadCommonConfig(reader);
+            ReadCommonConfig(reader);
 
             ushort TotalScenes = reader.ReadUInt16();
 
@@ -142,18 +142,18 @@ namespace RSDKv5
         public void Write(string filename)
         {
             using (Writer writer = new Writer(filename))
-                this.Write(writer);
+                Write(writer);
         }
 
         public void Write(Stream stream)
         {
             using (Writer writer = new Writer(stream))
-                this.Write(writer);
+                Write(writer);
         }
 
         internal void Write(Writer writer)
         {
-            base.WriteMagic(writer);
+            WriteMagic(writer);
 
             writer.WriteRSDKString(GameName);
             writer.WriteRSDKString(GameSubname);
@@ -162,7 +162,7 @@ namespace RSDKv5
             writer.Write(StartSceneCategoryIndex);
             writer.Write(StartSceneIndex);
 
-            base.WriteCommonConfig(writer);
+            WriteCommonConfig(writer);
 
             writer.Write((ushort)Categories.Select(x => x.Scenes.Count).Sum());
 

--- a/RSDKv5/Position.cs
+++ b/RSDKv5/Position.cs
@@ -53,5 +53,16 @@ namespace RSDKv5
             writer.Write(Y.Low);
             writer.Write(Y.High);
         }
+
+        public override string ToString()
+        {
+            StringBuilder sb = new StringBuilder("X: ");
+            sb.Append(X.High);
+            if (0 != X.Low) sb.Append($"[{X.Low}]");
+            sb.Append(", Y: ");
+            sb.Append(Y.High);
+            if (0 != Y.Low) sb.Append($"[{Y.Low}]");
+            return sb.ToString();
+        }
     }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-- cmd: 7z a ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\LICENSE
+- cmd: 7z a ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\Resources %APPVEYOR_BUILD_FOLDER%\LICENSE
 artifacts:
 - path: ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip
   name: ManiacEditor-Positivity

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.2.24.{build}
+version: 0.2.25.{build}
 skip_tags: true
 image: Visual Studio 2017
 configuration: Release
@@ -13,7 +13,7 @@ before_build:
 build:
   verbosity: minimal
 after_build:
-- cmd: 7z a ManiacEditor-Beta-OBE-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\LICENSE
+- cmd: 7z a ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.exe %APPVEYOR_BUILD_FOLDER%\%PLATFORM_DIR%\ManiacEditor\bin\Release\*.dll %APPVEYOR_BUILD_FOLDER%\LICENSE
 artifacts:
-- path: ManiacEditor-Beta-OBE-v%APPVEYOR_BUILD_VERSION%.zip
-  name: ManiacEditor-OBE
+- path: ManiacEditor-Beta-Positivity-v%APPVEYOR_BUILD_VERSION%.zip
+  name: ManiacEditor-Positivity


### PR DESCRIPTION
Adds support for flipping groups of entities by using the M and F keys, the same as used for flipping tiles.

It also adds rudimentary support for automatically flipping the orientation of entities. So if you're flip a spring vertically, and it was originally pointing down, it would now point up. Reducing the need to remember the magic values in the Attributes. This behaviour applies when flipping a single spring, or multiple springs.